### PR TITLE
fix: aplicar lazy loading a iframe de YouTube

### DIFF
--- a/index.html
+++ b/index.html
@@ -181,7 +181,8 @@
                         <iframe 
                             src="https://www.youtube-nocookie.com/embed/eY4jXLyNNV0" 
                             title="EL VUELO DEL MOSCARDÓN | Tráiler"
-                            frameborder="0" 
+                            frameborder="0"
+                            loading="lazy" 
                             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" 
                             referrerpolicy="strict-origin-when-cross-origin" 
                             allowfullscreen>


### PR DESCRIPTION
Al igual que con la foto lo hicimos con el  video de youtube para que no demore en cargar contenido multimedia