### PR TITLE
fix: agregar rel='noopener noreferrer' a enlaces externos

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,7 +253,7 @@
         <!-- Footer -->
         <footer class="footer">
             <div class="social-links">
-                <a href="https://github.com/FlavertT" target="_blank" class="social-link"><i class="fab fa-github"></i></a>
+                <a href="https://github.com/FlavertT" target="_blank" rel="noopener noreferrer" class="social-link"><i class="fab fa-github"></i></a>
                 <a href="#" class="social-link"><i class="fab fa-linkedin"></i></a>
                 <a href="#" class="social-link"><i class="fab fa-twitter"></i></a>
                 <a href="#" class="social-link"><i class="fab fa-instagram"></i></a>


### PR DESCRIPTION
Buena practica para evitar posible phishing 